### PR TITLE
Pinned Envoy version and forced apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM lyft/envoy
+FROM envoyproxy/envoy:v1.6.0
 
 WORKDIR /app
 
 ADD . /app
 
-RUN yes | apt-get install python-pip python-dev build-essential
+RUN apt-get update
+RUN apt-get install -y python-pip python-dev build-essential
 RUN pip install -r requirements.txt
 
 EXPOSE 8080


### PR DESCRIPTION
Hi,

Many thanks for creating this example, as it helped me diagnose some issues with LightStep. I had a few issues initially getting set up, and this was mostly due to the age of the repo (e.g. the Envoy Docker account has changed, and Envoy v2 is now the latest). I've updated the Dockerfile and pinned Envoy to v1.6, and everything is good to go now.

Best wishes,

Daniel